### PR TITLE
feat(collection): require at least one link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
 - '2.7'
 before_script:
 - yes | python setup.py install
-- git clone https://github.com/uc-cdis/dictionaryutils; cd dictionaryutils
+- git clone https://github.com/uc-cdis/dictionaryutils; cd dictionaryutils;
 script:
 - ./run_tests.sh
 deploy:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,0 @@
--e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
--e git+https://git@github.com/NCI-GDC/psqlgraph.git@7b5de7d56aa3159a9526940eb273579ddbf084ca#egg=psqlgraph
--e git+https://git@github.com/NCI-GDC/gdcdatamodel.git@755c6d7c380b69dc36dced55700bc9e24a084db1#egg=gdcdatamodel

--- a/gdcdictionary/schemas/aligned_reads_index.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index.yaml
@@ -22,18 +22,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: submitted_aligned_reads_files
-    backref: aligned_reads_indexes
-    label: derived_from
-    target_type: submitted_aligned_reads
-    multiplicity: one_to_one
+  - exclusive: false
     required: true
-  - name: core_metadata_collections
-    backref: aligned_reads_indexes
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_many
-    required: false
+    subgroup:
+    - name: submitted_aligned_reads_files
+      backref: aligned_reads_indexes
+      label: derived_from
+      target_type: submitted_aligned_reads
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: aligned_reads_indexes
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/experimental_metadata.yaml
+++ b/gdcdictionary/schemas/experimental_metadata.yaml
@@ -23,12 +23,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: experiments
-    backref: experiment_metadata_files
-    label: derived_from
-    target_type: experiment
-    multiplicity: many_to_many
+  - exclusive: false
     required: true
+    subgroup:
+    - name: core_metadata_collections
+      backref: experiment_metadata_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
+    - name: experiments
+      backref: experiment_metadata_files
+      label: derived_from
+      target_type: experiment
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id
@@ -63,3 +72,5 @@ properties:
       - string
   experiments:
     $ref: "_definitions.yaml#/to_one"
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/slide_image.yaml
+++ b/gdcdictionary/schemas/slide_image.yaml
@@ -23,18 +23,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: slides
-    backref: slide_images
-    label: data_from
-    target_type: slide
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
-  - name: core_metadata_collections
-    backref: slide_images
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_many
-    required: false
+    subgroup:
+    - name: slides
+      backref: slide_images
+      label: data_from
+      target_type: slide
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: slide_images
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -23,18 +23,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_aligned_reads_files # pretty ugly
-    label: data_from
-    target_type: read_group
-    multiplicity: one_to_many
+  - exclusive: false
     required: true
-  - name: core_metadata_collections
-    backref: submitted_aligned_reads_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_many
-    required: false
+    subgroup:
+    - name: read_groups
+      backref: submitted_aligned_reads_files # pretty ugly
+      label: data_from
+      target_type: read_group
+      multiplicity: one_to_many
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_aligned_reads_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/submitted_copy_number.yaml
+++ b/gdcdictionary/schemas/submitted_copy_number.yaml
@@ -23,21 +23,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
+  - exclusive: false
     required: true
     subgroup:
-      - name: aliquots
-        backref: submitted_copy_number_files
-        label: derived_from
-        target_type: aliquot
-        multiplicity: one_to_one
-        required: false
-      - name: read_groups
-        backref: submitted_copy_number_files
-        label: derived_from
-        target_type: read_group
-        multiplicity: many_to_many
-        required: false
+    - name: core_metadata_collections
+      backref: submitted_copy_number_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: aliquots
+          backref: submitted_copy_number_files
+          label: derived_from
+          target_type: aliquot
+          multiplicity: one_to_one
+          required: false
+        - name: read_groups
+          backref: submitted_copy_number_files
+          label: derived_from
+          target_type: read_group
+          multiplicity: many_to_many
+          required: false
 
 required:
   - submitter_id
@@ -76,4 +85,6 @@ properties:
   aliquots:
     $ref: "_definitions.yaml#/to_one"
   read_groups:
+    $ref: "_definitions.yaml#/to_many"
+  core_metadata_collections:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/submitted_methylation.yaml
+++ b/gdcdictionary/schemas/submitted_methylation.yaml
@@ -22,12 +22,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: submitted_methylation_files
-    label: data_from
-    target_type: aliquot
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
+    subgroup:
+    - name: core_metadata_collections
+      backref: submitted_methylation_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
+    - name: aliquots
+      backref: submitted_methylation_files
+      label: data_from
+      target_type: aliquot
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id
@@ -73,3 +82,5 @@ properties:
       - Illumina Infinium HumanMethylation450K
   aliquots:
     $ref: "_definitions.yaml#/to_one"
+  core_metadata_collections:
+    $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/submitted_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/submitted_somatic_mutation.yaml
@@ -23,12 +23,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_somatic_mutations
-    label: derived_from
-    target_type: read_group
-    multiplicity: many_to_many
-    required: true 
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: core_metadata_collections
+      backref: submitted_somatic_mutations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
+    - name: read_groups
+      backref: submitted_somatic_mutations
+      label: derived_from
+      target_type: read_group
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id
@@ -69,4 +78,6 @@ properties:
     description: "The total number of variants detected carrying a base change difference from the reference genome."
     type: integer
   read_groups:
+    $ref: "_definitions.yaml#/to_many"
+  core_metadata_collections:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -22,18 +22,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_unaligned_reads_files # pretty ugly
-    label: data_from
-    target_type: read_group
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
-  - name: core_metadata_collections
-    backref: submitted_unaligned_reads_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_many
-    required: false
+    subgroup:
+    - name: read_groups
+      backref: submitted_unaligned_reads_files # pretty ugly
+      label: data_from
+      target_type: read_group
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_unaligned_reads_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_many
+      required: false
 
 required:
   - submitter_id

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'dictionaryutils',
     ],
     dependency_links=[
-       "git+https://github.com/uc-cdis/dictionaryutils.git@11cfcb2c8bd579960c76f2b8136f8f00db7a3c01#egg=dictionaryutils",
+       "git+https://github.com/uc-cdis/dictionaryutils.git@2.0.4#egg=dictionaryutils",
     ],
     package_data={
         "gdcdictionary": [


### PR DESCRIPTION
- add collection link to data nodes that are missing it
- update link requirement to require at least one parent to present
- one of the node already uses subgroup to specify that it only wants exclusively one parent(aliquots/read_groups), so had to add support for nested subgroups in metaschema and datamodel validation)
depends on https://github.com/uc-cdis/gdcdatamodel/pull/8 https://github.com/uc-cdis/dictionaryutils/pull/28