### PR TITLE
PXP-2266 Fix/links: updated dictionary to omit submiter_id requirement in link project

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -13,13 +13,43 @@ parent_uuids:
         $ref: "#/UUID"
     uniqueItems: true
 
+foreign_key_project:
+    type: object
+    # Allow true here because we can have other unique keys defined on
+    # a target type
+    additionalProperties: true
+    # Can either use 'id' which are Gen3 IDs (UUID) or 'code'
+    # which is the user defined ID for project
+    properties:
+        id:
+            $ref: "#/UUID"
+        code:
+            type: string
+
+to_one_project:
+  anyOf:
+    - type: array
+      items:
+        $ref: "#/foreign_key_project"
+        minItems: 1
+        maxItems: 1
+    - $ref: "#/foreign_key_project"
+
+to_many_project:
+  anyOf:
+    - type: array
+      items:
+        $ref: "#/foreign_key_project"
+        minItems: 1
+    - $ref: "#/foreign_key_project"
+
 foreign_key:
     type: object
     # Allow true here because we can have other unique keys defined on
     # a target type
     additionalProperties: True
-    #Can either use 'id' which are GDC IDs (UUID) or 'submitter_id'
-    #which are user defined IDs ("submitter IDs in the backend")
+    # Can either use 'id' which are GDC IDs (UUID) or 'submitter_id'
+    # which are user defined IDs ("submitter IDs in the backend")
     properties:
         id:
             $ref: "#/UUID"

--- a/gdcdictionary/schemas/acknowledgement.yaml
+++ b/gdcdictionary/schemas/acknowledgement.yaml
@@ -51,7 +51,7 @@ properties:
     description: "The indvidiual or group being acknowledged by the project."
     type: string
   projects:
-    $ref: "_definitions.yaml#/to_many"
+    $ref: "_definitions.yaml#/to_many_project"
   project_id:
     type: string
   created_datetime:

--- a/gdcdictionary/schemas/core_metadata_collection.yaml
+++ b/gdcdictionary/schemas/core_metadata_collection.yaml
@@ -109,5 +109,5 @@ properties:
     type: string
 
   projects:
-    $ref: "_definitions.yaml#/to_one"
+    $ref: "_definitions.yaml#/to_one_project"
 

--- a/gdcdictionary/schemas/experiment.yaml
+++ b/gdcdictionary/schemas/experiment.yaml
@@ -98,7 +98,7 @@ properties:
     description: "Brief description of the data being provided for this experiment."
     type: string
   projects:
-    $ref: "_definitions.yaml#/to_one"
+    $ref: "_definitions.yaml#/to_one_project"
   project_id:
     $ref: "_definitions.yaml#/project_id"
   created_datetime:

--- a/gdcdictionary/schemas/keyword.yaml
+++ b/gdcdictionary/schemas/keyword.yaml
@@ -51,7 +51,7 @@ properties:
     description: "The name of the keyword."
     type: string
   projects:
-    $ref: "_definitions.yaml#/to_many"
+    $ref: "_definitions.yaml#/to_many_project"
   project_id:
     type: string
   created_datetime:

--- a/gdcdictionary/schemas/publication.yaml
+++ b/gdcdictionary/schemas/publication.yaml
@@ -52,7 +52,7 @@ properties:
   doi:
     type: string
   projects:
-    $ref: "_definitions.yaml#/to_many"
+    $ref: "_definitions.yaml#/to_many_project"
   project_id:
     type: string
   created_datetime:


### PR DESCRIPTION
Link project doesn't have submitter_id, updated dictionary accordingly.