### PR TITLE
get correct release version and deploy to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 python:
 - '2.7'
 
-install:
-- pip install pipenv
-
 before_script:
 - yes | python setup.py install
 - git clone https://github.com/uc-cdis/dictionaryutils; cd dictionaryutils;
@@ -48,5 +45,6 @@ env:
   - secure: P/TYBbm9u30RLGrfNVNMm689qOqHJyBniwKITfgPiK3aujeGdT6Z1XDNPYPgwlWKE5kDPSf1ZA3CfTj2rwUOKWfKANeIH7BRLh0n02hIIwAZUiV1u8/5pQk84mDH5UAMtVOwsAbbRof+tvEjjfrr0EmCGnhcbVrXo7f9jIUXiJcRCMdjGgMmmoRu5WQhIyVfK7n+Qr9p84Vml999VFQkiPcmGTrJxbPE6tiTQoWRWc9ak3q/SEmUUP1F31B5FhF74C5B5DKZyq+oEWmzeXe5noleZ0vzW2uy3qupHh2bj+SZC/WcfNRPxMc49Pjc9sa65GgaLsTvww2nQX6Ioycgz7OOiIayJLFOKlvQ4Fahow1zjjUEI4/5y3bL7vhXFLEUn0dxvWXanmWLsO8cmM0NQ/AeXhrd2/2pblVtBVrimzkQydJANgyTCw2E/Wbvxnkxyc5GfttfRKgABJ/mLWNlKQ4RQNhAXmD7CqH9kd7T1+oyiuQTOj6Bu8wN5IsGuqv41k4aufyq5LN+4F9/ugex05NBGtGm6a9byAq7XjOzpvFWoki8kwVIoJie8gA74kUf05iAl0iQVqCMFPrxNyeH2cngZgfi+rs7KhnoJ9ZctqCDHIg75xPt9heskn2pw59VU1tcs1QOmNEynEMsusC/wA/WbBQrx9ppVovqjvCaozg=
 
 after_deploy:
+- pip install pipenv
 - pipenv run pip install gen3git
 - pipenv run gen3git release

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,25 @@ before_script:
 - yes | python setup.py install
 - git clone https://github.com/uc-cdis/dictionaryutils; cd dictionaryutils;
 script:
-- ./run_tests.sh
+- "./run_tests.sh"
 deploy:
-  provider: s3
-  access_key_id: AKIAIKM5YAHQGFDE72SQ
-  secret_access_key:
-    secure: ZTcjEHtJnAM39kLA55EiePoqZncTPeEZNTFX7E5xkc3TLAqgJlpjpoH40Qq7cn5gzdZ0Z9YWlOCyIV0Va6Oxc7XJVK/lSzioelseKnz+yscUq8aAJluy1INx7uXEbiPwRNz+bfy5uYOU/Bn/+6/I4Wc3MbvNRdbwF57hXdn6WjD7s+/T65l2PL3iN4MqLRmzuC+BRztOugnWM6s/za7pcA7AP9j367HX0yt/31h9CPIZuGFSItWjmxEFAB7VfCqN+fF7ZisOwGRDJkzzEv6eJbpsCq1m1Jl3TYfQoX96mUh0Pa2frk69enDVSsOkDeQ82DrREf51wdfk6Gs/YmrrVSoaBM0Cm97Ssd7fr2erxTlIdfRvPDN3vncWzsnvVZHkez2owqWV9TEaAgbVsI6myINAX0Ibh8beLkCHjFLXYoOBglNGrc2DC2M9ZBpM18nJ2tZVAva2t53MSFtcRw06xu4E9+ZBMZeVacXM1BA7M6APQVSDwrHJk3BVgaz+Wi+iUFZkmCujI5xS1PNta+iVZ6yJyiMd2l2oLsikcs9qYI94aZvmHYFSxq+LdZfIpov/10dPt800jHDgszKcGJ4rGGZOTFguI7fDPrkkTgihLthRuBGc5umMI4hdJZ4CB1JXCkWK/wk7hdBuMye7VzAEc9XfFflAUb+3H7T1PfhC+MM=
-  bucket: dictionary-artifacts
-  local-dir: artifacts
-  upload-dir: datadictionary/$TRAVIS_BRANCH
-  skip_cleanup: true
-  on:
-    repo: uc-cdis/datadictionary
-    all_branches: true
+  matrix:
+  - provider: s3
+    access_key_id: AKIAIKM5YAHQGFDE72SQ
+    secret_access_key:
+      secure: ZTcjEHtJnAM39kLA55EiePoqZncTPeEZNTFX7E5xkc3TLAqgJlpjpoH40Qq7cn5gzdZ0Z9YWlOCyIV0Va6Oxc7XJVK/lSzioelseKnz+yscUq8aAJluy1INx7uXEbiPwRNz+bfy5uYOU/Bn/+6/I4Wc3MbvNRdbwF57hXdn6WjD7s+/T65l2PL3iN4MqLRmzuC+BRztOugnWM6s/za7pcA7AP9j367HX0yt/31h9CPIZuGFSItWjmxEFAB7VfCqN+fF7ZisOwGRDJkzzEv6eJbpsCq1m1Jl3TYfQoX96mUh0Pa2frk69enDVSsOkDeQ82DrREf51wdfk6Gs/YmrrVSoaBM0Cm97Ssd7fr2erxTlIdfRvPDN3vncWzsnvVZHkez2owqWV9TEaAgbVsI6myINAX0Ibh8beLkCHjFLXYoOBglNGrc2DC2M9ZBpM18nJ2tZVAva2t53MSFtcRw06xu4E9+ZBMZeVacXM1BA7M6APQVSDwrHJk3BVgaz+Wi+iUFZkmCujI5xS1PNta+iVZ6yJyiMd2l2oLsikcs9qYI94aZvmHYFSxq+LdZfIpov/10dPt800jHDgszKcGJ4rGGZOTFguI7fDPrkkTgihLthRuBGc5umMI4hdJZ4CB1JXCkWK/wk7hdBuMye7VzAEc9XfFflAUb+3H7T1PfhC+MM=
+    bucket: dictionary-artifacts
+    local-dir: artifacts
+    upload-dir: datadictionary/$TRAVIS_BRANCH
+    skip_cleanup: true
+    on:
+      repo: uc-cdis/datadictionary
+      all_branches: true
+  - provider: pypi
+    user: uc-ctds
+    skip_existing: true
+    on:
+      tags: true
+      branch: develop
+    password:
+      secure: qeCODwlCx6mECz/ITa6nxWZHcgW26OOkaknoziVbbmYCXTiL/PwjS7k7UJtRPS0TdN5edb99wZRXO/E+VTjmg1mQ9dGG0zztRdvflVzBDxbdNKlMo2ueNgLgL6Acpcf1hgLP9zMCTwiI5CQJmC5pALwPFz5KuMOzbTHs+EaifTRiHFBotPACTUmsFzUJWI91/TT87uBMlXV13CTBuTNhMlbg85ycEXgQNDW7WZZx9GC1dO8DxeFO1Jf2DMTzabqi23SKN+QIO4Q2HZ4f+oW3vCzzaVCW6rJZBhWRCsUsC8UHkAY22qE5/uKiJ0azdmcTLmXQaU1CEkZNNTrmVplp7CfggVj55jar2eSufz7w2hr39t1ouXoQ9tZC6l/v0yvqzvFZN9DYu5uFFm0OI0S2paSLaEW+Luc8yQij/TMDaf6O8gW2/g3uliJtk9aJ25m5n36zfRX5suByvsYtmBIRwdI67NpgqPULYz8UrCoey9b0Kijtv9NletyWcOa1cN4U0fm887zgFGud+2v0ubTaXot/FTWIc+vI6FouIDWxFDqOJvAYL8SezFnxW53sGhru0x8s49zLC/NJau4IPPOcQKAHSxJbDApBAeiFmB28+GIbc3inkY4L91hBQMykHQO+6/ePd2xw6Za7C2W8PHkb47OLRPLrLhjTVUSRSGByNyY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: python
+
 python:
 - '2.7'
+
+install:
+- pip install pipenv
+
 before_script:
 - yes | python setup.py install
 - git clone https://github.com/uc-cdis/dictionaryutils; cd dictionaryutils;
+
 script:
-- "./run_tests.sh"
+- ./run_tests.sh
+
+before_deploy:
+- sed -i.bak "s/=get_version()/='$TRAVIS_TAG'/g" setup.py
+- cat setup.py
+- if [ $(python setup.py --version) == '0.0.0' ]; then travis_terminate 1; fi
+
 deploy:
   matrix:
   - provider: s3
@@ -22,8 +34,19 @@ deploy:
   - provider: pypi
     user: uc-ctds
     skip_existing: true
+    skip_cleanup: true
     on:
       tags: true
+      repo: uc-cdis/datadictionary
       branch: develop
+      python: 2.7
     password:
       secure: qeCODwlCx6mECz/ITa6nxWZHcgW26OOkaknoziVbbmYCXTiL/PwjS7k7UJtRPS0TdN5edb99wZRXO/E+VTjmg1mQ9dGG0zztRdvflVzBDxbdNKlMo2ueNgLgL6Acpcf1hgLP9zMCTwiI5CQJmC5pALwPFz5KuMOzbTHs+EaifTRiHFBotPACTUmsFzUJWI91/TT87uBMlXV13CTBuTNhMlbg85ycEXgQNDW7WZZx9GC1dO8DxeFO1Jf2DMTzabqi23SKN+QIO4Q2HZ4f+oW3vCzzaVCW6rJZBhWRCsUsC8UHkAY22qE5/uKiJ0azdmcTLmXQaU1CEkZNNTrmVplp7CfggVj55jar2eSufz7w2hr39t1ouXoQ9tZC6l/v0yvqzvFZN9DYu5uFFm0OI0S2paSLaEW+Luc8yQij/TMDaf6O8gW2/g3uliJtk9aJ25m5n36zfRX5suByvsYtmBIRwdI67NpgqPULYz8UrCoey9b0Kijtv9NletyWcOa1cN4U0fm887zgFGud+2v0ubTaXot/FTWIc+vI6FouIDWxFDqOJvAYL8SezFnxW53sGhru0x8s49zLC/NJau4IPPOcQKAHSxJbDApBAeiFmB28+GIbc3inkY4L91hBQMykHQO+6/ePd2xw6Za7C2W8PHkb47OLRPLrLhjTVUSRSGByNyY=
+
+env:
+  global:
+  - secure: P/TYBbm9u30RLGrfNVNMm689qOqHJyBniwKITfgPiK3aujeGdT6Z1XDNPYPgwlWKE5kDPSf1ZA3CfTj2rwUOKWfKANeIH7BRLh0n02hIIwAZUiV1u8/5pQk84mDH5UAMtVOwsAbbRof+tvEjjfrr0EmCGnhcbVrXo7f9jIUXiJcRCMdjGgMmmoRu5WQhIyVfK7n+Qr9p84Vml999VFQkiPcmGTrJxbPE6tiTQoWRWc9ak3q/SEmUUP1F31B5FhF74C5B5DKZyq+oEWmzeXe5noleZ0vzW2uy3qupHh2bj+SZC/WcfNRPxMc49Pjc9sa65GgaLsTvww2nQX6Ioycgz7OOiIayJLFOKlvQ4Fahow1zjjUEI4/5y3bL7vhXFLEUn0dxvWXanmWLsO8cmM0NQ/AeXhrd2/2pblVtBVrimzkQydJANgyTCw2E/Wbvxnkxyc5GfttfRKgABJ/mLWNlKQ4RQNhAXmD7CqH9kd7T1+oyiuQTOj6Bu8wN5IsGuqv41k4aufyq5LN+4F9/ugex05NBGtGm6a9byAq7XjOzpvFWoki8kwVIoJie8gA74kUf05iAl0iQVqCMFPrxNyeH2cngZgfi+rs7KhnoJ9ZctqCDHIg75xPt9heskn2pw59VU1tcs1QOmNEynEMsusC/wA/WbBQrx9ppVovqjvCaozg=
+
+after_deploy:
+- pipenv run pip install gen3git
+- pipenv run gen3git release

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include NOTICE
+include Pipfile
+include Pipfile.lock
+recursive-include schemas/ *.yaml

--- a/gdcdictionary/schema_test.py
+++ b/gdcdictionary/schema_test.py
@@ -23,7 +23,7 @@ from gdcdictionary import gdcdictionary
 
 def load_yaml_schema(path):
     with open(path, 'r') as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_DIR = os.path.join(CUR_DIR, 'examples')
 project1 = load_yaml_schema(os.path.join(CUR_DIR, 'schemas/projects/project1.yaml'))
@@ -97,7 +97,7 @@ def validate_schemata(schemata, metaschema):
 class SchemaTest(unittest.TestCase):
     def setUp(self):
         self.dictionary = gdcdictionary
-        self.definitions = yaml.load(open(os.path.join(CUR_DIR, 'schemas','_definitions.yaml'),'r'))
+        self.definitions = yaml.safe_load(open(os.path.join(CUR_DIR, 'schemas','_definitions.yaml'),'r'))
 
     def test_schemas(self):
         validate_schemata(self.dictionary.schema, self.dictionary.metaschema)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,27 @@
+from subprocess import check_output
+
 from setuptools import setup, find_packages
+
+def get_version():
+    # https://github.com/uc-cdis/dictionaryutils/pull/37#discussion_r257898408
+    try:
+        tag = check_output(
+            ["git", "describe", "--tags", "--abbrev=0", "--match=[0-9]*"]
+        )
+        return tag.decode("utf-8").strip("\n")
+    except Exception:
+        raise RuntimeError(
+            "The version number cannot be extracted from git tag in this source "
+            "distribution; please either download the source from PyPI, or check out "
+            "from GitHub and make sure that the git CLI is available."
+        )
+
 
 setup(
     name='gdcdictionary',
-    version='0.0.0',
+    version=get_version(),
+    description="Gen3 generic data dictionary",
+    license="Apache",
     packages=find_packages(),
     install_requires=[
         'PyYAML==3.11',

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
     license="Apache",
     packages=find_packages(),
     install_requires=[
-        'PyYAML==3.11',
-        'jsonschema==2.5.1',
+        'PyYAML>=3.11',
+        'jsonschema>=2.5.1',
         'dictionaryutils',
     ],
     dependency_links=[

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,6 @@ setup(
         'jsonschema>=2.5.1',
         'dictionaryutils',
     ],
-    dependency_links=[
-       "git+https://github.com/uc-cdis/dictionaryutils.git@2.0.4#egg=dictionaryutils",
-    ],
     package_data={
         "gdcdictionary": [
             "schemas/*.yaml",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license="Apache",
     packages=find_packages(),
     install_requires=[
-        'PyYAML>=3.11',
+        'PyYAML~=5.1',
         'jsonschema>=2.5.1',
         'dictionaryutils',
     ],


### PR DESCRIPTION
At the moment we have 1.1.0 on pypi, which is not the latest version. 

Also we decided to make the next tag 1.2.0 because there's already a 1.1.0 from 2016

### Deployment changes
deploy to pypi in addition to s3
get version from tag
add gen3git (release notes helper) upon release

### Dependency updates
bump pyyaml to 5.1 and use safe_load()