### PR TITLE
Chore(py3): Make syntax compatible with py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
 - '2.7'
+- '3.6'
 
 before_script:
 - yes | python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
 - '2.7'
-- '3.6'
 
 before_script:
 - yes | python setup.py install

--- a/gdcdictionary/schema_test.py
+++ b/gdcdictionary/schema_test.py
@@ -78,7 +78,7 @@ def validate_entity(entity, schemata, project=None, name=''):
 
 def validate_schemata(schemata, metaschema):
     # validate schemata
-    print('Validating schemas against metaschema... '),
+    print('Validating schemas against metaschema... ')
     for s in schemata.values():
         validate(s, metaschema)
 
@@ -172,7 +172,7 @@ if __name__ == '__main__':
         doc = json.load(f)
         if args.invalid:
             try:
-                print("CHECK if {0} is invalid:".format(f.name)),
+                print("CHECK if {0} is invalid:".format(f.name))
                 print(type(doc))
                 if type(doc) == dict:
                     validate_entity(doc, dictionary.schema)
@@ -187,7 +187,7 @@ if __name__ == '__main__':
             else:
                 raise Exception("Expected invalid, but validated.")
         else:
-            print ("CHECK if {0} is valid:".format(f.name)),
+            print("CHECK if {0} is valid:".format(f.name))
             if type(doc) == dict:
                 validate_entity(doc, dictionary.schema)
             elif type(doc) == list:

--- a/gdcdictionary/schema_test.py
+++ b/gdcdictionary/schema_test.py
@@ -8,6 +8,7 @@ Examples are at the end.
 
 """
 
+from __future__ import print_function
 
 from jsonschema import validate, ValidationError
 import copy
@@ -78,7 +79,7 @@ def validate_entity(entity, schemata, project=None, name=''):
 
 def validate_schemata(schemata, metaschema):
     # validate schemata
-    print('Validating schemas against metaschema... ')
+    print('Validating schemas against metaschema... ', end=" ")
     for s in schemata.values():
         validate(s, metaschema)
 
@@ -172,7 +173,7 @@ if __name__ == '__main__':
         doc = json.load(f)
         if args.invalid:
             try:
-                print("CHECK if {0} is invalid:".format(f.name))
+                print("CHECK if {0} is invalid:".format(f.name), end=" ")
                 print(type(doc))
                 if type(doc) == dict:
                     validate_entity(doc, dictionary.schema)
@@ -187,7 +188,7 @@ if __name__ == '__main__':
             else:
                 raise Exception("Expected invalid, but validated.")
         else:
-            print("CHECK if {0} is valid:".format(f.name))
+            print("CHECK if {0} is valid:".format(f.name), end=" ")
             if type(doc) == dict:
                 validate_entity(doc, dictionary.schema)
             elif type(doc) == list:


### PR DESCRIPTION
Cleans up print statements in this repo to prepare for py3 upgrade. 

Underlying travis file is still testing on a py27 environment since dictionaryutils/master is currently on python2 but once that's upgraded, we can also switch travis to use py3 for this repo.